### PR TITLE
Fixed docker setup and A3 event function call error at CHO simulation

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,4 +5,6 @@ services:
     build: 
       context: .
       dockerfile: dockerfile
+    image: 5g-handover-sim:latest
+    working_dir: /app
     command: bash

--- a/handover-simulator/src/simulator_3gpp_rel16.py
+++ b/handover-simulator/src/simulator_3gpp_rel16.py
@@ -191,7 +191,7 @@ def simulate_user(user=int, simDataframes=None, intervals=None, Hys=float, A3Off
                     gnb_hys = Hys_FR2 if gnb_band == "FR2" else Hys
                     
                     # Check A3 event for this gNB with appropriate Hys
-                    if check_A3_event(gnb_rsrp, connected_rsrp, A3Offset, gnb_hys, gnb_id, connected_gnb_id):
+                    if check_A3_event(gnb_rsrp, connected_rsrp, A3Offset, gnb_hys):
                         # A3 event detected! Enter CHO mode
                         logging.info(f"UE {user}: A3 event detected from GNB {gnb_id} ({gnb_band}, Hys={gnb_hys}dB). Entering CHO mode")
                         cho_mode = True
@@ -219,7 +219,7 @@ def simulate_user(user=int, simDataframes=None, intervals=None, Hys=float, A3Off
                                 candidate_ttt = TTT
                             
                             # Check if candidate meets A3 condition
-                            if check_A3_event(candidate_rsrp, connected_rsrp, A3Offset, candidate_hys, candidate_id, connected_gnb_id):
+                            if check_A3_event(candidate_rsrp, connected_rsrp, A3Offset, candidate_hys):
                                 logging.debug(f"UE {user}: GNB {candidate_id} ({candidate_band}) added as CHO candidate (TTT={candidate_ttt}s, Hys={candidate_hys}dB)")
                                 cho_candidates[candidate_id] = {
                                     'timer': 0,
@@ -252,7 +252,7 @@ def simulate_user(user=int, simDataframes=None, intervals=None, Hys=float, A3Off
                     
                     # Check if A3-2 event occurred (candidate no longer suitable)
                     # A3-2: RSRP_neighbor < RSRP_serving + A3Offset - Hys
-                    if check_A3_2_event(candidate_rsrp, connected_rsrp, A3Offset, candidate_hys, candidate_id, connected_gnb_id):
+                    if check_A3_2_event(candidate_rsrp, connected_rsrp, A3Offset, candidate_hys):
                         # Calculate the A3-2 threshold for logging
                         a32_threshold = connected_rsrp + A3Offset - candidate_hys
                         # A3-2 event detected - candidate falls below threshold

--- a/readme.md
+++ b/readme.md
@@ -60,17 +60,13 @@ You can set the environment in two ways:
 2. Native
 
 ### 1. Using Docker
-1. execute docker-compose in the root directory:
-```bash
-docker-compose up -d
-```
-1. Make sure the following dependencies are installed:
+1.1. Make sure the following dependencies are installed:
 * [Docker](https://www.docker.com/)
 * [Docker Compose](https://docs.docker.com/compose/)
 
-1. Please refer to the [Docker installation guide](https://docs.docker.com/engine/install/) and the [Docker Compose installation guide](https://docs.docker.com/compose/install/) for your specific distribution.
+Please refer to the [Docker installation guide](https://docs.docker.com/engine/install/) and the [Docker Compose installation guide](https://docs.docker.com/compose/install/) for your specific distribution.
 
-2. Ensure that the Docker services are up and running. You can check the status of the services by running:
+1.2. Ensure that the Docker services are up and running. You can check the status of the services by running:
 ```bash
 sudo systemctl status docker.service
 ```
@@ -81,6 +77,17 @@ The user should be added to the Docker group to interact without root privileges
 ```bash
 sudo usermod -aG docker $USER
 ```
+1.3 execute docker-compose in the root directory:
+```bash
+docker compose up -d --build
+```
+1.4 run the service:
+```bash
+docker compose run simulator
+```
+
+1.5. Go to 2.3 step 
+
 ### 2.Native
 Please refer to the [5G-LENA documentation](https://cttc-lena.gitlab.io/nr/html/index.html#getting-started) for detailed instructions on how to set up ns-3 and 5G-LENA.
 
@@ -88,22 +95,22 @@ Please refer to the [5G-LENA documentation](https://cttc-lena.gitlab.io/nr/html/
  
 To build and run the project, follow these instructions:
 
-1. Open a terminal and navigate to the ns3-dev folder:
+2.1. Open a terminal and navigate to the ns3-dev folder:
 
 ```bash
 cd ns3-dev
 ```
 
-2. Configure the build profile for optimized building by running the following command:
+2.2. Configure the build profile for optimized building by running the following command:
  
 ```bash
 ./ns3 configure --build-profile=optimized
 ```
-3. Once the build process is complete, navigate to the handover-simulator folder:
+2.3. Once the build process is complete, navigate to the handover-simulator folder:
 ```bash
 cd ../handover-simulator/src
 ```
-4. Start the handover simulator by running the following command:
+2.4. Start the handover simulator by running the following command:
 ```bash
 python3 main.py
 ```


### PR DESCRIPTION
-  docker-compose has deprecated and was throwing ContainerConfig error. Updated readme with docker compose. [askubuntu](https://askubuntu.com/questions/1508129/docker-compose-giving-containerconfig-errors-after-update-today)
- In simulator_3gpp_rel16.py the `check_A3_event` functions were being called with 6 parameters instead of 4. 
